### PR TITLE
feat: audit feedback

### DIFF
--- a/contracts/passThrough/PassThroughManager.sol
+++ b/contracts/passThrough/PassThroughManager.sol
@@ -36,8 +36,9 @@ contract PassThroughManager is Ownable {
         public
         onlyOwner
     {
+        // Avoid overflow
         require(
-            _time + block.timestamp <= MAX_TIME,
+            MAX_TIME >= block.timestamp && _time <= MAX_TIME - block.timestamp,
             "The time should be lower than permitted"
         );
         _target.disableMethod(_signature, _time);

--- a/contracts/passThrough/PassThroughManager.sol
+++ b/contracts/passThrough/PassThroughManager.sol
@@ -37,7 +37,7 @@ contract PassThroughManager is Ownable {
         onlyOwner
     {
         require(
-            _time <= MAX_TIME - block.timestamp,
+            _time + block.timestamp <= MAX_TIME,
             "The time should be lower than permitted"
         );
         _target.disableMethod(_signature, _time);

--- a/test/PassThrough.js
+++ b/test/PassThrough.js
@@ -245,6 +245,20 @@ contract('PassThrough', function([deployer, owner, operator, holder, hacker]) {
         ),
         'The time should be lower than permitted'
       )
+
+      await increaseTime(blockTime)
+      blockTime = (await getBlock()).timestamp
+
+      blockTime.should.be.gt(MAX_TIME)
+      await assertRevert(
+        passThroughManager.disableMethod(
+          passThrough.address,
+          ownerOf,
+          duration.days(1),
+          fromDeployer
+        ),
+        'The time should be lower than permitted'
+      )
     })
   })
 


### PR DESCRIPTION
Fix math based on the audit:

```
The MAX_TIME validation on line 40 of PassThroughManager.sol is not valid due to an
underflow event.
The require validates if _time is lower or equal than the delta of MAX_TIME (a future date)
and the current Unix time, this operation goes below zero after the current Unix time
exceeds the MAX_TIME constant, because all operations are performed using unsigned
integers, it underflows and becomes a higher number.
It renders the check upon _time ineffective after MAX_TIME is exceeded, allowing the owner
of the contracts to extend the duration of the locking.
```